### PR TITLE
Fix capitalization of Wasm

### DIFF
--- a/Instructions.md
+++ b/Instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-For each WASM SIMD instruction, you can see the number of instructions that v8 generates.
+For each Wasm SIMD instruction, you can see the number of instructions that v8 generates.
 
 Note that while instruction count isn't always indicative of performance, it can give you an insight into what instructions to use and what to avoid.
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # wasm-simd
 
-This repository intends to help write efficient WASM SIMD programs.
+This repository intends to help write efficient Wasm SIMD programs.
 
 The performance information collected here is targeting v8 x64/arm64 as the most frequently used browser/architecture combination.
 
 # Why?
 
-Writing cross-platform SIMD code is challenging - WASM SIMD provides a nice abstraction that guarantees the same results between platforms, but unifying behavior comes at a performance cost. Some operations are fast on all platforms, whereas some other operations represent "performance cliffs" - they might be fast on one platform and slow on another platform.
+Writing cross-platform SIMD code is challenging - Wasm SIMD provides a nice abstraction that guarantees the same results between platforms, but unifying behavior comes at a performance cost. Some operations are fast on all platforms, whereas some other operations represent "performance cliffs" - they might be fast on one platform and slow on another platform.
 
-Being aware of the microarchitectural differences helps when writing cross-platform code, and these guides intend to help navigate the space of WASM SIMD performance by guiding the programmers to use efficient instructions and avoid inefficient or imbalanced instructions.
+Being aware of the microarchitectural differences helps when writing cross-platform code, and these guides intend to help navigate the space of Wasm SIMD performance by guiding the programmers to use efficient instructions and avoid inefficient or imbalanced instructions.
 
 # What?
 
-[Instructions](Instructions.md) describes the performance of various WASM SIMD instructions on x64/arm64.
+[Instructions](Instructions.md) describes the performance of various Wasm SIMD instructions on x64/arm64.
 
-[Shuffles](Shuffles.md) describes the performance of various WASM SIMD byte shuffles on x64/arm64.
+[Shuffles](Shuffles.md) describes the performance of various Wasm SIMD byte shuffles on x64/arm64.
 
 # Inspecting assembly output
 
-The best way to analyze the performance of a WASM SIMD kernel today is to study the assembly output for the target architecture. Using a debug v8 build (which is easy to install using https://github.com/GoogleChromeLabs/jsvu), the following command will produce the assembly output for the WASM code that is compiled by the JS module/program:
+The best way to analyze the performance of a Wasm SIMD kernel today is to study the assembly output for the target architecture. Using a debug v8 build (which is easy to install using https://github.com/GoogleChromeLabs/jsvu), the following command will produce the assembly output for the Wasm code that is compiled by the JS module/program:
 
 ```
 $ v8-debug --experimental-wasm-simd --print-wasm-code --no-liftoff --single-threaded --no-debug-code input.js


### PR DESCRIPTION
Wasm is not an acronym, hence should not be all-uppercase.
According to official documentation, it's either WebAssembly or Wasm.